### PR TITLE
Enhancement rotate changed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.1.0
+* Add rotate_changed. Fixes #7.
+
 ## Version 1.0.2
 Sebastian Stigler (7):
 * Bugfix for issue #1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AALeC
-version=1.0.2
+version=1.1.0
 author=Winfried Bantel <winfried.bantel@hs-aalen.de>, Sebastian Stiglger <sebastian.stigler@hs-aalen.de>
 maintainer=Winfried Bantel <winfried.bantel@hs-aalen.de>
 sentence=A library for the Aalener Lern-Computer (AALeC)

--- a/src/AALeC.cpp
+++ b/src/AALeC.cpp
@@ -125,6 +125,14 @@ int c_AALeC::get_rotate() {
 }
 
 
+int c_AALeC::rotate_changed() {
+  int rc = 0;
+  if (drehgeber_int !=drehgeber_int_alt)
+    rc = 1, drehgeber_int_alt = drehgeber_int;
+  return rc;
+}
+
+
 void c_AALeC::reset_rotate() {
   drehgeber_int = 0;
 }

--- a/src/AALeC.h
+++ b/src/AALeC.h
@@ -53,6 +53,7 @@ class c_AALeC {
 
     /* Methods for the value of the encoder */
     int get_rotate();
+    int rotate_changed();
     void reset_rotate();
 
     /* Methods for the temperature and humidity sensor */
@@ -79,7 +80,7 @@ class c_AALeC {
   private:
     void dht11_mess();
 
-    int drehgeber_int;
+    int drehgeber_int = 0, drehgeber_int_alt = 0;
     NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart800KbpsMethod> * strip;
     SimpleDHT11 dht11;
     uint8_t temp_int, hum_int;


### PR DESCRIPTION
Die Methode rotate_changed ermöglicht es den monierten code durch folgenden zu ersetzen:

```c
  if (aalec.rotate_changed()) {
    // ... Hier kommt die Aktion, wenn sich der Encoder geändert hat
  }
```