### PR TITLE
NeoEsp8266Uart800KbpsMethod no longer supported

### DIFF
--- a/src/AALeC.cpp
+++ b/src/AALeC.cpp
@@ -57,7 +57,7 @@ void c_AALeC::init() {
   Serial.flush();
 
   Wire.begin();
-  strip = new NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart800KbpsMethod>(3, PIN_RGB_STRIP);
+  strip = new NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart1Ws2812xMethod>(3, PIN_RGB_STRIP);
   strip->Begin();
   strip->ClearTo(RgbColor(0, 0, 0));
   strip->Show();


### PR DESCRIPTION
Replaced NeoEsp8266Uart800KbpsMethod by NeoEsp8266Uart1Ws2812xMethod for NeoPixelBus.
https://github.com/probonopd/ESP8266HueEmulator/issues/120