### PR TITLE
Fix aalec.init(); crashing

### DIFF
--- a/src/AALeC.cpp
+++ b/src/AALeC.cpp
@@ -7,7 +7,7 @@
 c_AALeC aalec;
 
 
-void AALeC_ISR_DREH() {
+void ICACHE_RAM_ATTR AALeC_ISR_DREH() {
   static int16_t val, z, n;
   const static int8_t delta[4][4] = {
     {0, 1, 2, 0},
@@ -57,7 +57,7 @@ void c_AALeC::init() {
   Serial.flush();
 
   Wire.begin();
-  strip = new NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart800KbpsMethod>(3, PIN_RGB_STRIP);
+  strip = new NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart1Ws2812xMethod>(3, PIN_RGB_STRIP);
   strip->Begin();
   strip->ClearTo(RgbColor(0, 0, 0));
   strip->Show();

--- a/src/AALeC.h
+++ b/src/AALeC.h
@@ -81,7 +81,7 @@ class c_AALeC {
     void dht11_mess();
 
     int drehgeber_int = 0, drehgeber_int_alt = 0;
-    NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart800KbpsMethod> * strip;
+    NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart1Ws2812xMethod> * strip;
     SimpleDHT11 dht11;
     uint8_t temp_int, hum_int;
     uint32_t last_dht11 = -1010;


### PR DESCRIPTION
This fixes  crashing. Actually the 'attachInterrupt(PIN_ENCODER_TRACK_1, AALeC_ISR_DREH, CHANGE);    attachInterrupt(PIN_ENCODER_TRACK_2, AALeC_ISR_DREH, CHANGE);' lines which alec.init() is calling are the reason for the crash.
Why does this fix work? See:
https://arduino.stackexchange.com/questions/67017/esp-nodemcu-amica-attachinterrupt-crash-program
https://stackoverflow.com/questions/58113937/esp8266-arduino-why-is-it-necessary-to-add-the-icache-ram-attr-macro-to-isrs-an


Also includes the Fix from https://github.com/informatik-aalen/AALeC/pull/10